### PR TITLE
chore: suppress LSP warnings

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,7 @@
+{
+"reportMissingImports": false,
+"reportUnknownMemberType": "none",
+"reportUnknownVariableType": "none",
+"reportWildcardImportFromLibrary": "none",
+"reportGeneralTypeIssues": "none"
+}

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,9 @@
+line-length = 120
+select = ["E", "F", "I"]
+ignore = ["F403", "F405", "E402", "E501"]  # Ignore wildcard import issues
+exclude = [
+    ".git",
+    "__pycache__",
+    "build",
+    "dist",
+]


### PR DESCRIPTION
Per Jeremy Howard (creator of FastHTML):
> There aren't any LSPs that can handle dynamically typed python (in fact it's not possible, since LSPs rely on static typing), so best to just turn off their warning in FastHTML projects. (Although there is a pep8 example in fasthtml/examples if you want to see how to write a FastHTML app in a way that will probably make your editor happy.)